### PR TITLE
add log text color

### DIFF
--- a/easylogger/inc/color.h
+++ b/easylogger/inc/color.h
@@ -1,0 +1,45 @@
+#ifndef __COLORS_H__
+#define __COLORS_H__
+
+/* use Escape Sequence control the text color
+ * details please reference http://www.cnblogs.com/clover-toeic/p/4031618.html
+ */
+
+#define ESC_START       "\e["
+#define ESC_END         "\e[0m"
+
+//front color
+#define F_BLACK   "30;"
+#define F_RED     "31;"
+#define F_GREEN   "32;"
+#define F_YELLOW  "33;"
+#define F_BLUE    "34;"
+#define F_MAGENTA "35;"
+#define F_CYAN    "36;"
+#define F_WHITE   "37;"
+
+//background color
+#define B_BLACK   "40;"
+#define B_RED     "41;"
+#define B_GREEN   "42;"
+#define B_YELLOW  "43;"
+#define B_BLUE    "44;"
+#define B_MAGENTA "45;"
+#define B_CYAN    "46;"
+#define B_WHITE   "47;"
+
+//show style
+#define NORMAL    "0m"
+#define BOLD      "1m"
+#define BLINK     "5m"
+#define NO_BOLD   "22m"
+
+//[front color] + [background color] + [show style]
+#define COLOR_ASSERT    F_MAGENTA B_BLACK NO_BOLD
+#define COLOR_ERROR     F_RED B_BLACK NO_BOLD
+#define COLOR_WARN      F_YELLOW B_BLACK NO_BOLD
+#define COLOR_INFO      F_BLUE B_BLACK NO_BOLD
+#define COLOR_DEBUG     F_GREEN B_BLACK NO_BOLD
+#define COLOR_VERBOSE   F_WHITE B_BLACK NO_BOLD
+
+#endif

--- a/easylogger/inc/elog.h
+++ b/easylogger/inc/elog.h
@@ -132,6 +132,8 @@ ElogErrCode elog_init(void);
 void elog_start(void);
 void elog_set_output_enabled(bool enabled);
 bool elog_get_output_enabled(void);
+void elog_set_text_color_enabled(bool enabled);
+bool elog_get_text_color_enabled(void);
 void elog_set_fmt(uint8_t level, size_t set);
 void elog_set_filter(uint8_t level, const char *tag, const char *keyword);
 void elog_set_filter_lvl(uint8_t level);

--- a/easylogger/src/elog.c
+++ b/easylogger/src/elog.c
@@ -49,6 +49,8 @@ static const char *level_output_info[] = {
 };
 /* the output lock enable or disable. default is enable */
 static bool output_lock_enabled = true;
+/* the log text color enable or disable. default is enable */
+static bool text_color_enabled = true;
 /* the output is locked before enable. */
 static bool output_is_locked_before_enable = false;
 /* the output is locked before disable. */
@@ -96,6 +98,24 @@ void elog_set_output_enabled(bool enabled) {
 
     elog.output_enabled = enabled;
 }
+
+/**
+ * set log text color enable or disable
+ * 
+ * @param enabled TRUE: enable FALSE:disable
+ */
+ void elog_set_text_color_enabled(bool enabled) {
+	 text_color_enabled = enabled;
+ }
+ 
+ /**
+  * get log text color enable status
+  *
+  * @return enable or disable
+  */
+  bool elog_get_text_color_enabled(void) {
+	  return text_color_enabled;
+  }
 
 /**
  * get output is enable or disable
@@ -241,33 +261,37 @@ void elog_output(uint8_t level, const char *tag, const char *file, const char *f
 
     /* lock output */
     output_lock();
+	
 	/* add Escape Sequence start sign and color info*/
-    log_len += elog_strcpy(log_len, log_buf + log_len, ESC_START);
-    char *color = NULL;
-    switch(level)
-    {
-        case ELOG_LVL_ASSERT:
-            color = (char*) COLOR_ASSERT;
-            break;
-        case ELOG_LVL_ERROR:
-            color = (char*) COLOR_ERROR;
-            break;
-        case ELOG_LVL_WARN:
-            color = (char*) COLOR_WARN;
-            break;
-        case ELOG_LVL_INFO:
-            color = (char*) COLOR_INFO;
-            break;
-        case ELOG_LVL_DEBUG:
-            color = (char*) COLOR_DEBUG;
-            break;
-        case ELOG_LVL_VERBOSE:
-            color = (char*) COLOR_VERBOSE;
-            break;
-        default:
-            ;
-    }
-    log_len += elog_strcpy(log_len, log_buf + log_len, color);
+	if(text_color_enabled) {
+		log_len += elog_strcpy(log_len, log_buf + log_len, ESC_START);
+		char *color = NULL;
+		switch(level)
+		{
+			case ELOG_LVL_ASSERT:
+				color = (char*) COLOR_ASSERT;
+				break;
+			case ELOG_LVL_ERROR:
+				color = (char*) COLOR_ERROR;
+				break;
+			case ELOG_LVL_WARN:
+				color = (char*) COLOR_WARN;
+				break;
+			case ELOG_LVL_INFO:
+				color = (char*) COLOR_INFO;
+				break;
+			case ELOG_LVL_DEBUG:
+				color = (char*) COLOR_DEBUG;
+				break;
+			case ELOG_LVL_VERBOSE:
+				color = (char*) COLOR_VERBOSE;
+				break;
+			default:
+				;
+		}
+		log_len += elog_strcpy(log_len, log_buf + log_len, color);
+	}
+	
     /* package level info */
     if (get_fmt_enabled(level, ELOG_FMT_LVL)) {
         log_len += elog_strcpy(log_len, log_buf + log_len, level_output_info[level]);
@@ -363,7 +387,9 @@ void elog_output(uint8_t level, const char *tag, const char *file, const char *f
     }
 
     /* add Escape Sequence end sign */
-    log_len += elog_strcpy(log_len, log_buf + log_len, ESC_END);
+	if(text_color_enabled) {
+		log_len += elog_strcpy(log_len, log_buf + log_len, ESC_END);
+	}
 	
     /* output log */
     elog_port_output(log_buf, log_len);

--- a/easylogger/src/elog.c
+++ b/easylogger/src/elog.c
@@ -26,6 +26,7 @@
  * Created on: 2015-04-28
  */
 
+#include "color.h"
 #include <elog.h>
 #include <string.h>
 #include <stdarg.h>
@@ -240,6 +241,33 @@ void elog_output(uint8_t level, const char *tag, const char *file, const char *f
 
     /* lock output */
     output_lock();
+	/* add Escape Sequence start sign and color info*/
+    log_len += elog_strcpy(log_len, log_buf + log_len, ESC_START);
+    char *color = NULL;
+    switch(level)
+    {
+        case ELOG_LVL_ASSERT:
+            color = (char*) COLOR_ASSERT;
+            break;
+        case ELOG_LVL_ERROR:
+            color = (char*) COLOR_ERROR;
+            break;
+        case ELOG_LVL_WARN:
+            color = (char*) COLOR_WARN;
+            break;
+        case ELOG_LVL_INFO:
+            color = (char*) COLOR_INFO;
+            break;
+        case ELOG_LVL_DEBUG:
+            color = (char*) COLOR_DEBUG;
+            break;
+        case ELOG_LVL_VERBOSE:
+            color = (char*) COLOR_VERBOSE;
+            break;
+        default:
+            ;
+    }
+    log_len += elog_strcpy(log_len, log_buf + log_len, color);
     /* package level info */
     if (get_fmt_enabled(level, ELOG_FMT_LVL)) {
         log_len += elog_strcpy(log_len, log_buf + log_len, level_output_info[level]);
@@ -334,6 +362,9 @@ void elog_output(uint8_t level, const char *tag, const char *file, const char *f
         strcpy(log_buf + ELOG_BUF_SIZE - newline_len, ELOG_NEWLINE_SIGN);
     }
 
+    /* add Escape Sequence end sign */
+    log_len += elog_strcpy(log_len, log_buf + log_len, ESC_END);
+	
     /* output log */
     elog_port_output(log_buf, log_len);
 


### PR DESCRIPTION
add some code to make different level log show different color , this feature is enabled by default; 
you can enable or disable this feature by calling `void elog_set_text_color_enabled(bool enabled)` ,
or get status of text color enabed by calling `bool elog_get_color_enabled(void)`;
![easylogger_text_color](https://cloud.githubusercontent.com/assets/6802386/19719568/2adadd1a-9b9d-11e6-9f4c-1e5cec585e39.png)