### PR TITLE
实现了syslog形式的log-rotate

### DIFF
--- a/demo/os/linux/easylogger/plugins/file/elog_file_cfg.h
+++ b/demo/os/linux/easylogger/plugins/file/elog_file_cfg.h
@@ -35,4 +35,7 @@
 /* EasyLogger file log plugin's using file max size */
 #define ELOG_FILE_MAX_SIZE  (10 * 1024 * 1024)
 
+/* EasyLogger file log plugin's using max rotate file count */
+#define ELOG_FILE_MAX_ROTATE 10
+
 #endif /* _ELOG_FILE_CFG_H_ */

--- a/easylogger/plugins/file/elog_file.h
+++ b/easylogger/plugins/file/elog_file.h
@@ -49,12 +49,14 @@ extern "C" {
 typedef struct {
     char *name;              /* file name */
     size_t max_size;         /* file max size */
+    int max_rotate;          /* max rotate file count */
 } ElogFileCfg;
 
 /* elog_file.c */
 ElogErrCode elog_file_init(void);
 void elog_file_write(const char *log, size_t size);
 void elog_file_config(ElogFileCfg *cfg);
+void elog_file_rotate(void);
 void elog_file_deinit(void);
 
 /* elog_file_port.c */

--- a/easylogger/plugins/file/elog_file_cfg.h
+++ b/easylogger/plugins/file/elog_file_cfg.h
@@ -35,4 +35,7 @@
 /* EasyLogger file log plugin's using file max size */
 #define ELOG_FILE_MAX_SIZE             /* @note you must define it for a value */
 
+/* EasyLogger file log plugin's using max rotate file count */
+#define ELOG_FILE_MAX_ROTATE           /* @note you must define it for a value */
+
 #endif /* _ELOG_FILE_CFG_H_ */


### PR DESCRIPTION
若当前日志xxx.log大小超过local_cfg.max_size，如果配置的local_cfg.max_rotate > 0，将执行log-rotate操作：
将每个 xxx.log.n-1 移动到 xxx.log.n（n < local_cfg.max_rotate），
将 xxx.log 移动到 xxx.log.0，
再重新打开 xxx.log 写入新的日志。

使用linux demo测试通过。

文件名字符串用的malloc分配，自己实际应用时其实用的形如path[n+10]的动态数组，但是这需要c99标准的编译器。或者用alloca可能也行？