### PR TITLE
修复异步模式下概率性导致输出日志不完整的问题

### DIFF
--- a/easylogger/src/elog_async.c
+++ b/easylogger/src/elog_async.c
@@ -283,8 +283,6 @@ static void *async_output(void *arg) {
     size_t get_log_size = 0;
     static char poll_get_buf[ELOG_ASYNC_POLL_GET_LOG_BUF_SIZE];
 
-    ELOG_ASSERT(init_ok);
-
     while(true) {
         /* waiting log */
         sem_wait(&output_notice);


### PR DESCRIPTION
Summary:
[背景]:异步输出模式开启、断言开启，elog_async.c在初始化时，elog_async_init创建子线程完成后，
子线程处理函数async_output在一开始会对全局变量init_ok进行断言，如果为false，那么就无法进入
后续sem_wait流程，进行结果输出了;而init_ok是在子线程创建完之后，elog_async_init最后才设置
为true的，这样程序的正确执行就取决于父子线程的调度顺序了
[解决办法]:子线程的处理程序中无需对init_ok进行判断，因为在while循环体中sem_wait会保证只有在
有需要输出的内容时，才会触发后续的内容输出过程