### PR TITLE
解决elog_hexdump中数据偏移地址的问题

### DIFF
--- a/easylogger/src/elog.c
+++ b/easylogger/src/elog.c
@@ -699,7 +699,7 @@ void elog_hexdump(const char *name, uint8_t width, uint8_t *buf, uint16_t size)
 
     for (i = 0; i < size; i += width) {
         /* package header */
-        fmt_result = snprintf(log_buf, ELOG_LINE_BUF_SIZE, "D/HEX %s: %04X-%04X: ", name, i, i + width);
+        fmt_result = snprintf(log_buf, ELOG_LINE_BUF_SIZE, "D/HEX %s: %04X-%04X: ", name, i, i + width - 1);
         /* calculate log length */
         if ((fmt_result > -1) && (fmt_result <= ELOG_LINE_BUF_SIZE)) {
             log_len = fmt_result;


### PR DESCRIPTION
修改前hexdump效果：
图片
![图片](https://user-images.githubusercontent.com/11486676/62409651-3b771200-b60d-11e9-95c9-59545eb874f8.png)
修改后效果：
![图片](https://user-images.githubusercontent.com/11486676/62409644-1387ae80-b60d-11e9-8e37-89ecbbbcf21d.png)
