### PR TITLE
docs: fix simple typo, samllest -> smallest

### DIFF
--- a/demo/non_os/stm32f10x/Libraries/CMSIS_EWARM/Include/core_cm3.h
+++ b/demo/non_os/stm32f10x/Libraries/CMSIS_EWARM/Include/core_cm3.h
@@ -1422,7 +1422,7 @@ __STATIC_INLINE uint32_t NVIC_GetPriority(IRQn_Type IRQn)
     The function encodes the priority for an interrupt with the given priority group,
     preemptive priority value, and subpriority value.
     In case of a conflict between priority grouping and available
-    priority bits (__NVIC_PRIO_BITS), the samllest possible priority group is set.
+    priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
 
     \param [in]     PriorityGroup  Used priority group.
     \param [in]   PreemptPriority  Preemptive priority value (starting from 0).
@@ -1450,7 +1450,7 @@ __STATIC_INLINE uint32_t NVIC_EncodePriority (uint32_t PriorityGroup, uint32_t P
     The function decodes an interrupt priority value with a given priority group to
     preemptive priority value and subpriority value.
     In case of a conflict between priority grouping and available
-    priority bits (__NVIC_PRIO_BITS) the samllest possible priority group is set.
+    priority bits (__NVIC_PRIO_BITS) the smallest possible priority group is set.
 
     \param [in]         Priority   Priority value, which can be retrieved with the function \ref NVIC_GetPriority().
     \param [in]     PriorityGroup  Used priority group.

--- a/demo/non_os/stm32f10x/Libraries/CMSIS_EWARM/Include/core_cm4.h
+++ b/demo/non_os/stm32f10x/Libraries/CMSIS_EWARM/Include/core_cm4.h
@@ -1567,7 +1567,7 @@ __STATIC_INLINE uint32_t NVIC_GetPriority(IRQn_Type IRQn)
     The function encodes the priority for an interrupt with the given priority group,
     preemptive priority value, and subpriority value.
     In case of a conflict between priority grouping and available
-    priority bits (__NVIC_PRIO_BITS), the samllest possible priority group is set.
+    priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
 
     \param [in]     PriorityGroup  Used priority group.
     \param [in]   PreemptPriority  Preemptive priority value (starting from 0).
@@ -1595,7 +1595,7 @@ __STATIC_INLINE uint32_t NVIC_EncodePriority (uint32_t PriorityGroup, uint32_t P
     The function decodes an interrupt priority value with a given priority group to
     preemptive priority value and subpriority value.
     In case of a conflict between priority grouping and available
-    priority bits (__NVIC_PRIO_BITS) the samllest possible priority group is set.
+    priority bits (__NVIC_PRIO_BITS) the smallest possible priority group is set.
 
     \param [in]         Priority   Priority value, which can be retrieved with the function \ref NVIC_GetPriority().
     \param [in]     PriorityGroup  Used priority group.

--- a/demo/non_os/stm32f10x/Libraries/CMSIS_EWARM/Include/core_sc300.h
+++ b/demo/non_os/stm32f10x/Libraries/CMSIS_EWARM/Include/core_sc300.h
@@ -1393,7 +1393,7 @@ __STATIC_INLINE uint32_t NVIC_GetPriority(IRQn_Type IRQn)
     The function encodes the priority for an interrupt with the given priority group,
     preemptive priority value, and subpriority value.
     In case of a conflict between priority grouping and available
-    priority bits (__NVIC_PRIO_BITS), the samllest possible priority group is set.
+    priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
 
     \param [in]     PriorityGroup  Used priority group.
     \param [in]   PreemptPriority  Preemptive priority value (starting from 0).
@@ -1421,7 +1421,7 @@ __STATIC_INLINE uint32_t NVIC_EncodePriority (uint32_t PriorityGroup, uint32_t P
     The function decodes an interrupt priority value with a given priority group to
     preemptive priority value and subpriority value.
     In case of a conflict between priority grouping and available
-    priority bits (__NVIC_PRIO_BITS) the samllest possible priority group is set.
+    priority bits (__NVIC_PRIO_BITS) the smallest possible priority group is set.
 
     \param [in]         Priority   Priority value, which can be retrieved with the function \ref NVIC_GetPriority().
     \param [in]     PriorityGroup  Used priority group.

--- a/demo/non_os/stm32f10x/Libraries/CMSIS_RVMDK/CM3/CoreSupport/core_cm3.h
+++ b/demo/non_os/stm32f10x/Libraries/CMSIS_RVMDK/CM3/CoreSupport/core_cm3.h
@@ -1627,7 +1627,7 @@ static __INLINE uint32_t NVIC_GetPriority(IRQn_Type IRQn)
  * Encode the priority for an interrupt with the given priority group,
  * preemptive priority value and sub priority value.
  * In case of a conflict between priority grouping and available
- * priority bits (__NVIC_PRIO_BITS) the samllest possible priority group is set.
+ * priority bits (__NVIC_PRIO_BITS) the smallest possible priority group is set.
  *
  * The returned priority value can be used for NVIC_SetPriority(...) function
  */
@@ -1658,7 +1658,7 @@ static __INLINE uint32_t NVIC_EncodePriority (uint32_t PriorityGroup, uint32_t P
  * Decode an interrupt priority value with the given priority group to 
  * preemptive priority value and sub priority value.
  * In case of a conflict between priority grouping and available
- * priority bits (__NVIC_PRIO_BITS) the samllest possible priority group is set.
+ * priority bits (__NVIC_PRIO_BITS) the smallest possible priority group is set.
  *
  * The priority value can be retrieved with NVIC_GetPriority(...) function
  */

--- a/demo/os/rt-thread/stm32f10x/Libraries/CMSIS_EWARM/Include/core_cm3.h
+++ b/demo/os/rt-thread/stm32f10x/Libraries/CMSIS_EWARM/Include/core_cm3.h
@@ -1422,7 +1422,7 @@ __STATIC_INLINE uint32_t NVIC_GetPriority(IRQn_Type IRQn)
     The function encodes the priority for an interrupt with the given priority group,
     preemptive priority value, and subpriority value.
     In case of a conflict between priority grouping and available
-    priority bits (__NVIC_PRIO_BITS), the samllest possible priority group is set.
+    priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
 
     \param [in]     PriorityGroup  Used priority group.
     \param [in]   PreemptPriority  Preemptive priority value (starting from 0).
@@ -1450,7 +1450,7 @@ __STATIC_INLINE uint32_t NVIC_EncodePriority (uint32_t PriorityGroup, uint32_t P
     The function decodes an interrupt priority value with a given priority group to
     preemptive priority value and subpriority value.
     In case of a conflict between priority grouping and available
-    priority bits (__NVIC_PRIO_BITS) the samllest possible priority group is set.
+    priority bits (__NVIC_PRIO_BITS) the smallest possible priority group is set.
 
     \param [in]         Priority   Priority value, which can be retrieved with the function \ref NVIC_GetPriority().
     \param [in]     PriorityGroup  Used priority group.

--- a/demo/os/rt-thread/stm32f10x/Libraries/CMSIS_EWARM/Include/core_cm4.h
+++ b/demo/os/rt-thread/stm32f10x/Libraries/CMSIS_EWARM/Include/core_cm4.h
@@ -1567,7 +1567,7 @@ __STATIC_INLINE uint32_t NVIC_GetPriority(IRQn_Type IRQn)
     The function encodes the priority for an interrupt with the given priority group,
     preemptive priority value, and subpriority value.
     In case of a conflict between priority grouping and available
-    priority bits (__NVIC_PRIO_BITS), the samllest possible priority group is set.
+    priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
 
     \param [in]     PriorityGroup  Used priority group.
     \param [in]   PreemptPriority  Preemptive priority value (starting from 0).
@@ -1595,7 +1595,7 @@ __STATIC_INLINE uint32_t NVIC_EncodePriority (uint32_t PriorityGroup, uint32_t P
     The function decodes an interrupt priority value with a given priority group to
     preemptive priority value and subpriority value.
     In case of a conflict between priority grouping and available
-    priority bits (__NVIC_PRIO_BITS) the samllest possible priority group is set.
+    priority bits (__NVIC_PRIO_BITS) the smallest possible priority group is set.
 
     \param [in]         Priority   Priority value, which can be retrieved with the function \ref NVIC_GetPriority().
     \param [in]     PriorityGroup  Used priority group.

--- a/demo/os/rt-thread/stm32f10x/Libraries/CMSIS_EWARM/Include/core_sc300.h
+++ b/demo/os/rt-thread/stm32f10x/Libraries/CMSIS_EWARM/Include/core_sc300.h
@@ -1393,7 +1393,7 @@ __STATIC_INLINE uint32_t NVIC_GetPriority(IRQn_Type IRQn)
     The function encodes the priority for an interrupt with the given priority group,
     preemptive priority value, and subpriority value.
     In case of a conflict between priority grouping and available
-    priority bits (__NVIC_PRIO_BITS), the samllest possible priority group is set.
+    priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
 
     \param [in]     PriorityGroup  Used priority group.
     \param [in]   PreemptPriority  Preemptive priority value (starting from 0).
@@ -1421,7 +1421,7 @@ __STATIC_INLINE uint32_t NVIC_EncodePriority (uint32_t PriorityGroup, uint32_t P
     The function decodes an interrupt priority value with a given priority group to
     preemptive priority value and subpriority value.
     In case of a conflict between priority grouping and available
-    priority bits (__NVIC_PRIO_BITS) the samllest possible priority group is set.
+    priority bits (__NVIC_PRIO_BITS) the smallest possible priority group is set.
 
     \param [in]         Priority   Priority value, which can be retrieved with the function \ref NVIC_GetPriority().
     \param [in]     PriorityGroup  Used priority group.

--- a/demo/os/rt-thread/stm32f10x/Libraries/CMSIS_RVMDK/CM3/CoreSupport/core_cm3.h
+++ b/demo/os/rt-thread/stm32f10x/Libraries/CMSIS_RVMDK/CM3/CoreSupport/core_cm3.h
@@ -1627,7 +1627,7 @@ static __INLINE uint32_t NVIC_GetPriority(IRQn_Type IRQn)
  * Encode the priority for an interrupt with the given priority group,
  * preemptive priority value and sub priority value.
  * In case of a conflict between priority grouping and available
- * priority bits (__NVIC_PRIO_BITS) the samllest possible priority group is set.
+ * priority bits (__NVIC_PRIO_BITS) the smallest possible priority group is set.
  *
  * The returned priority value can be used for NVIC_SetPriority(...) function
  */
@@ -1658,7 +1658,7 @@ static __INLINE uint32_t NVIC_EncodePriority (uint32_t PriorityGroup, uint32_t P
  * Decode an interrupt priority value with the given priority group to 
  * preemptive priority value and sub priority value.
  * In case of a conflict between priority grouping and available
- * priority bits (__NVIC_PRIO_BITS) the samllest possible priority group is set.
+ * priority bits (__NVIC_PRIO_BITS) the smallest possible priority group is set.
  *
  * The priority value can be retrieved with NVIC_GetPriority(...) function
  */


### PR DESCRIPTION
There is a small typo in demo/non_os/stm32f10x/Libraries/CMSIS_EWARM/Include/core_cm3.h, demo/non_os/stm32f10x/Libraries/CMSIS_EWARM/Include/core_cm4.h, demo/non_os/stm32f10x/Libraries/CMSIS_EWARM/Include/core_sc300.h, demo/non_os/stm32f10x/Libraries/CMSIS_RVMDK/CM3/CoreSupport/core_cm3.h, demo/os/rt-thread/stm32f10x/Libraries/CMSIS_EWARM/Include/core_cm3.h, demo/os/rt-thread/stm32f10x/Libraries/CMSIS_EWARM/Include/core_cm4.h, demo/os/rt-thread/stm32f10x/Libraries/CMSIS_EWARM/Include/core_sc300.h, demo/os/rt-thread/stm32f10x/Libraries/CMSIS_RVMDK/CM3/CoreSupport/core_cm3.h.

Should read `smallest` rather than `samllest`.

