### PR TITLE
提高buf为空时的elog_flush() 性能

### DIFF
--- a/easylogger/src/elog_buf.c
+++ b/easylogger/src/elog_buf.c
@@ -82,16 +82,16 @@ void elog_buf_output(const char *log, size_t size) {
  * flush all buffered logs to output device
  */
 void elog_flush(void) {
-    if(buf_write_size){
-        /* lock output */
-        elog_output_lock();
-        /* output log */
-        elog_port_output(log_buf, buf_write_size);
-        /* reset write index */
-        buf_write_size = 0;
-        /* unlock output */
-        elog_output_unlock();
-    }
+    if(!buf_write_size)
+        return;
+    /* lock output */
+    elog_output_lock();
+    /* output log */
+    elog_port_output(log_buf, buf_write_size);
+    /* reset write index */
+    buf_write_size = 0;
+    /* unlock output */
+    elog_output_unlock();
 }
 
 /**

--- a/easylogger/src/elog_buf.c
+++ b/easylogger/src/elog_buf.c
@@ -82,14 +82,16 @@ void elog_buf_output(const char *log, size_t size) {
  * flush all buffered logs to output device
  */
 void elog_flush(void) {
-    /* lock output */
-    elog_output_lock();
-    /* output log */
-    elog_port_output(log_buf, buf_write_size);
-    /* reset write index */
-    buf_write_size = 0;
-    /* unlock output */
-    elog_output_unlock();
+    if(buf_write_size){
+        /* lock output */
+        elog_output_lock();
+        /* output log */
+        elog_port_output(log_buf, buf_write_size);
+        /* reset write index */
+        buf_write_size = 0;
+        /* unlock output */
+        elog_output_unlock();
+    }
 }
 
 /**

--- a/easylogger/src/elog_buf.c
+++ b/easylogger/src/elog_buf.c
@@ -82,7 +82,7 @@ void elog_buf_output(const char *log, size_t size) {
  * flush all buffered logs to output device
  */
 void elog_flush(void) {
-    if(!buf_write_size)
+    if (buf_write_size == 0)
         return;
     /* lock output */
     elog_output_lock();


### PR DESCRIPTION
先判断buf中是否有数据，再进行上锁-输出-解锁的操作，避免buf为空时的频繁上/解锁操作