### PR TITLE
add deinit for linux

### DIFF
--- a/demo/os/linux/easylogger/port/elog_file_port.c
+++ b/demo/os/linux/easylogger/port/elog_file_port.c
@@ -55,6 +55,8 @@ static struct sembuf const down = {0, -1, SEM_UNDO};
 
 static void lock_init(void);
 static int lock_open(void);
+static void lock_deinit(void);
+
 /**
  * EasyLogger flile log pulgin port initialize
  *
@@ -83,12 +85,13 @@ void inline elog_file_port_unlock(void)
 {
     semid == -1 ? -1 : semop(semid, (struct sembuf *)&up, 1);
 }
+
 /**
  * file log deinit
  */
 void elog_file_port_deinit(void)
 {
-
+    lock_deinit();
 }
 
 /**
@@ -157,4 +160,12 @@ static int lock_open(void)
     return id;
 err:
     return -1;
+}
+
+/**
+ * deinitialize the lock 
+ */
+static void lock_deinit(void)
+{
+    semid = -1;
 }

--- a/demo/os/linux/easylogger/port/elog_port.c
+++ b/demo/os/linux/easylogger/port/elog_port.c
@@ -55,6 +55,19 @@ ElogErrCode elog_port_init(void) {
 }
 
 /**
+ * EasyLogger port deinitialize
+ *
+ */
+void elog_port_deinit(void) {
+#ifdef ELOG_FILE_ENABLE
+    elog_file_deinit();
+#endif
+
+    pthread_mutex_destroy(&output_lock);
+}
+
+
+/**
  * output log port interface
  *
  * @param log output of log

--- a/easylogger/inc/elog.h
+++ b/easylogger/inc/elog.h
@@ -177,7 +177,9 @@ typedef enum {
 
 /* elog.c */
 ElogErrCode elog_init(void);
+void elog_deinit(void);
 void elog_start(void);
+void elog_stop(void);
 void elog_set_output_enabled(bool enabled);
 bool elog_get_output_enabled(void);
 void elog_set_text_color_enabled(bool enabled);

--- a/easylogger/plugins/file/elog_file.c
+++ b/easylogger/plugins/file/elog_file.c
@@ -143,23 +143,32 @@ void elog_file_deinit(void)
 {
     ELOG_ASSERT(init_ok);
 
+    ElogFileCfg cfg = {NULL, 0, 0};
+
+    elog_file_config(&cfg);
+
     elog_file_port_deinit();
-    fclose(fp);
+
+    init_ok = false;
 }
 
 void elog_file_config(ElogFileCfg *cfg)
 {
-    if (fp) {
-        fclose(fp);
-    }
-
     elog_file_port_lock();
 
-    local_cfg.name = cfg->name;
-    local_cfg.max_size = cfg->max_size;
-    local_cfg.max_rotate = cfg->max_rotate;
+    if (fp) {
+        fclose(fp);
+        fp = NULL;
+    }
 
-    fp = fopen(local_cfg.name, "a+");
+    if (cfg != NULL) {
+        local_cfg.name = cfg->name;
+        local_cfg.max_size = cfg->max_size;
+        local_cfg.max_rotate = cfg->max_rotate;
+
+        if (local_cfg.name != NULL && strlen(local_cfg.name) > 0)
+            fp = fopen(local_cfg.name, "a+");
+    }
 
     elog_file_port_unlock();
 }

--- a/easylogger/port/elog_port.c
+++ b/easylogger/port/elog_port.c
@@ -42,6 +42,16 @@ ElogErrCode elog_port_init(void) {
 }
 
 /**
+ * EasyLogger port deinitialize
+ *
+ */
+void elog_port_deinit(void) {
+
+    /* add your code here */
+
+}
+
+/**
  * output log port interface
  *
  * @param log output of log

--- a/easylogger/src/elog.c
+++ b/easylogger/src/elog.c
@@ -201,9 +201,36 @@ ElogErrCode elog_init(void) {
 }
 
 /**
+ * EasyLogger deinitialize.
+ *
+ */
+void elog_deinit(void) {
+    extern ElogErrCode elog_port_deinit(void);
+    extern ElogErrCode elog_async_deinit(void);
+
+    if (!elog.init_ok) {
+        return ;
+    }
+    
+#ifdef ELOG_ASYNC_OUTPUT_ENABLE
+    elog_async_deinit();
+#endif
+
+    /* port deinitialize */
+    elog_port_deinit();
+
+    elog.init_ok = false;
+}
+
+
+/**
  * EasyLogger start after initialize.
  */
 void elog_start(void) {
+    if (!elog.init_ok) {
+        return ;
+    }
+    
     /* enable output */
     elog_set_output_enabled(true);
 
@@ -216,6 +243,28 @@ void elog_start(void) {
     /* show version */
     log_i("EasyLogger V%s is initialize success.", ELOG_SW_VERSION);
 }
+
+/**
+ * EasyLogger stop after initialize.
+ */
+void elog_stop(void) {
+    if (!elog.init_ok) {
+        return ;
+    }
+
+    /* disable output */
+    elog_set_output_enabled(false);
+
+#if defined(ELOG_ASYNC_OUTPUT_ENABLE)
+    elog_async_enabled(false);
+#elif defined(ELOG_BUF_OUTPUT_ENABLE)
+    elog_buf_enabled(false);
+#endif
+
+    /* show version */
+    log_i("EasyLogger V%s is deinitialize success.", ELOG_SW_VERSION);
+}
+
 
 /**
  * set output enable or disable


### PR DESCRIPTION
增加linux下elog_stop及elog_deinit操作，停止日志输出，回收锁、信号量、线程，关闭日志文件

valgrind查看资源情况：
valgrind --tool=memcheck --leak-check=full --show-reachable=yes --log-file=1.log ./out/EasyLoggerLinuxDemo

未调用deinit:
==9980== Memcheck, a memory error detector
==9980== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==9980== Using Valgrind-3.11.0 and LibVEX; rerun with -h for copyright info
==9980== Command: ./out/EasyLoggerLinuxDemo
==9980== Parent PID: 78219
==9980== 
==9980== 
==9980== HEAP SUMMARY:
==9980==     in use at exit: 824 bytes in 2 blocks
==9980==   total heap usage: 10,022 allocs, 10,020 frees, 170,153 bytes allocated
==9980== 
==9980== 272 bytes in 1 blocks are possibly lost in loss record 1 of 2
==9980==    at 0x4C2FB55: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==9980==    by 0x40138E4: allocate_dtv (dl-tls.c:322)
==9980==    by 0x40138E4: _dl_allocate_tls (dl-tls.c:539)
==9980==    by 0x4E4226E: allocate_stack (allocatestack.c:588)
==9980==    by 0x4E4226E: pthread_create@@GLIBC_2.2.5 (pthread_create.c:539)
==9980==    by 0x403610: elog_async_init (elog_async.c:347)
==9980==    by 0x401388: elog_init (elog.c:175)
==9980==    by 0x4043E0: main (main.c:44)
==9980== 
==9980== 552 bytes in 1 blocks are still reachable in loss record 2 of 2
==9980==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==9980==    by 0x50C4CEC: __fopen_internal (iofopen.c:69)
==9980==    by 0x4038DC: elog_file_rotate (elog_file.c:104)
==9980==    by 0x403A41: elog_file_write (elog_file.c:124)
==9980==    by 0x403EBC: elog_port_output (elog_port.c:81)
==9980==    by 0x4034BA: elog_async_output (elog_async.c:272)
==9980==    by 0x4026E6: elog_output (elog.c:708)
==9980==    by 0x404568: test_elog (main.c:101)
==9980==    by 0x40444E: main (main.c:72)
==9980== 
==9980== LEAK SUMMARY:
==9980==    definitely lost: 0 bytes in 0 blocks
==9980==    indirectly lost: 0 bytes in 0 blocks
==9980==      possibly lost: 272 bytes in 1 blocks
==9980==    still reachable: 552 bytes in 1 blocks
==9980==         suppressed: 0 bytes in 0 blocks
==9980== 
==9980== For counts of detected and suppressed errors, rerun with: -v
==9980== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)

调用deinit后:
==10303== Memcheck, a memory error detector
==10303== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==10303== Using Valgrind-3.11.0 and LibVEX; rerun with -h for copyright info
==10303== Command: ./out/EasyLoggerLinuxDemo
==10303== Parent PID: 78219
==10303== 
==10303== 
==10303== HEAP SUMMARY:
==10303==     in use at exit: 0 bytes in 0 blocks
==10303==   total heap usage: 10,022 allocs, 10,022 frees, 170,153 bytes allocated
==10303== 
==10303== All heap blocks were freed -- no leaks are possible
==10303== 
==10303== For counts of detected and suppressed errors, rerun with: -v
==10303== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

