### PR TITLE
优化linux下elog_port_get_time函数

### DIFF
--- a/demo/os/linux/easylogger/port/elog_port.c
+++ b/demo/os/linux/easylogger/port/elog_port.c
@@ -104,16 +104,14 @@ void elog_port_output_unlock(void) {
  */
 const char *elog_port_get_time(void) {
     static char cur_system_time[24] = { 0 };
-    time_t timep;
-    struct tm *p;
 
-    time(&timep);
-    p = localtime(&timep);
-    if (p == NULL) {
-        return "";
-    }
-    snprintf(cur_system_time, 18, "%02d-%02d %02d:%02d:%02d", p->tm_mon + 1, p->tm_mday,
-            p->tm_hour, p->tm_min, p->tm_sec);
+    time_t cur_t;
+    struct tm cur_tm;
+
+    time(&cur_t);
+    localtime_r(&cur_t, &cur_tm);
+
+    strftime(cur_system_time, sizeof(cur_system_time), "%Y-%m-%d %T", &cur_tm);
 
     return cur_system_time;
 }


### PR DESCRIPTION
1、修改localtime函数为localtime_r线程安全版本
2、修改snprintf函数为strftime提高效率

解释：
localtime函数内部会调用malloc函数，频繁分配释放内存，使用gdb查看堆栈如下：
(gdb) bt
0  **__GI___libc_malloc** (bytes=15) at malloc.c:2909
1  0x00007ffff787b50a in **__GI___strdup** (s=0x7ffff797e227 "/etc/localtime") at strdup.c:42
2  0x00007ffff78add8b in **tzset_internal** (explicit=<optimized out>, always=<optimized out>) at tzset.c:438
3  **__tz_convert** (timer=0x7fffffffe178, use_localtime=1, tp=0x7ffff7bb94a0 <_tmbuf>) at tzset.c:621
4  0x000000000040340a in **elog_port_get_time** () at ../easylogger/port/elog_port.c:126
5  0x0000000000401c9f in elog_output (level=3 '\003', tag=0x403c22 "elog", file=0x403c00 "../../../../easylogger/src/elog.c", 
    func=0x403f70 <__FUNCTION__.2787> "elog_start", line=244, format=0x403bd8 "EasyLogger V%s is initialize success.") at ../../../../easylogger/src/elog.c:614
6  0x0000000000400fbe in elog_start () at ../../../../easylogger/src/elog.c:244
7  0x0000000000403917 in main () at main.c:58

修改前，使用valgrind可以看到写1w条日志，整个程序有10,010次内存分配和释放动作
==56651== Memcheck, a memory error detector                                                                                                                                   
==56651== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al. 
==56651== Using Valgrind-3.11.0 and LibVEX; rerun with -h for copyright info
==56651== Command: ./out/EasyLoggerLinuxDemo
==56651== Parent PID: 33581
==56651== 
==56651== 
==56651== HEAP SUMMARY:
==56651==     in use at exit: 0 bytes in 0 blocks
==56651==   **total heap usage: 10,010 allocs, 10,010 frees, 160,737 bytes allocated**
==56651== 
==56651== All heap blocks were freed -- no leaks are possible
==56651== 
==56651== For counts of detected and suppressed errors, rerun with: -v
==56651== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

修改后，整个程序内存分配和释放动作降为10次
==53852== Memcheck, a memory error detector                                                                                                                                   
==53852== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al. 
==53852== Using Valgrind-3.11.0 and LibVEX; rerun with -h for copyright info
==53852== Command: ./out/EasyLoggerLinuxDemo
==53852== Parent PID: 33581
==53852== 
==53852== 
==53852== HEAP SUMMARY:
==53852==     in use at exit: 0 bytes in 0 blocks
==53852==   **total heap usage: 10 allocs, 10 frees, 10,737 bytes allocated**
==53852== 
==53852== All heap blocks were freed -- no leaks are possible
==53852== 
==53852== For counts of detected and suppressed errors, rerun with: -v
==53852== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)


修改前后写1w条日志时间对比（同步模式，注释了elog_port_output里的printf输出，仅写文件）：
修改前（约**58000us**）：
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo 
spend_time:57852us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo 
spend_time:58032us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo 
spend_time:57533us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo 
spend_time:62501us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo 
spend_time:56868us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo 
spend_time:60107us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo 
spend_time:59254us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo 
spend_time:56499us
修改后（约**44000us**）：
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo 
spend_time:47057us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo 
spend_time:42264us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo 
spend_time:42754us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo 
spend_time:46612us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo 
spend_time:46921us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo 
spend_time:42024us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo 
spend_time:42334us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo 
spend_time:43038us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo 
spend_time:42723us