### PR TITLE
optimize async log

### DIFF
--- a/demo/os/linux/easylogger/inc/elog_cfg.h
+++ b/demo/os/linux/easylogger/inc/elog_cfg.h
@@ -31,10 +31,12 @@
 
 /* enable log output. default open this macro */
 #define ELOG_OUTPUT_ENABLE
+/* enable terminal output. default open this macro */
+#define ELOG_TERMINAL_ENABLE
 /* enable log write file. default open this macro */
 #define ELOG_FILE_ENABLE
 /* enable flush file cache. default open this macro */
-#define ELOG_FILE_FLUSH_CAHCE_ENABLE
+#define ELOG_FILE_FLUSH_CACHE_ENABLE
 /* setting static output log level */
 #define ELOG_OUTPUT_LVL                      ELOG_LVL_VERBOSE
 /* enable assert check */
@@ -58,7 +60,7 @@
 /* the highest output level for async mode, other level will sync output */
 #define ELOG_ASYNC_OUTPUT_LVL                ELOG_LVL_DEBUG
 /* buffer size for asynchronous output mode */
-#define ELOG_ASYNC_OUTPUT_BUF_SIZE           (ELOG_LINE_BUF_SIZE * 100)
+#define ELOG_ASYNC_OUTPUT_BUF_SIZE           (ELOG_LINE_BUF_SIZE * 50)
 /* each asynchronous output's log which must end with newline sign */
 //#define ELOG_ASYNC_LINE_OUTPUT
 /* asynchronous output mode using POSIX pthread implementation */

--- a/demo/os/linux/easylogger/port/elog_port.c
+++ b/demo/os/linux/easylogger/port/elog_port.c
@@ -75,7 +75,10 @@ void elog_port_deinit(void) {
  */
 void elog_port_output(const char *log, size_t size) {
     /* output to terminal */
+#ifdef ELOG_TERMINAL_ENABLE
     printf("%.*s", (int)size, log);
+#endif
+
 #ifdef ELOG_FILE_ENABLE
     /* write the file */
     elog_file_write(log, size);

--- a/demo/os/windows/easylogger/inc/elog_cfg.h
+++ b/demo/os/windows/easylogger/inc/elog_cfg.h
@@ -34,7 +34,7 @@
 /* enable log write file. default open this macro */
 #define ELOG_FILE_ENABLE
 /* enable flush file cache. default open this macro */
-#define ELOG_FILE_FLUSH_CAHCE_ENABLE
+#define ELOG_FILE_FLUSH_CACHE_ENABLE
 /* setting static output log level */
 #define ELOG_OUTPUT_LVL                      ELOG_LVL_VERBOSE
 /* enable assert check */

--- a/easylogger/plugins/file/elog_file.c
+++ b/easylogger/plugins/file/elog_file.c
@@ -131,7 +131,7 @@ void elog_file_write(const char *log, size_t size)
 
     fwrite(log, size, 1, fp);
 
-#ifdef ELOG_FILE_FLUSH_CAHCE_ENABLE
+#ifdef ELOG_FILE_FLUSH_CACHE_ENABLE
     fflush(fp);
 #endif
 

--- a/easylogger/src/elog_async.c
+++ b/easylogger/src/elog_async.c
@@ -47,8 +47,14 @@
 #define ELOG_ASYNC_OUTPUT_PTHREAD_PRIORITY       (sched_get_priority_max(SCHED_RR) - 1)
 #endif
 /* output thread poll get log buffer size  */
+#ifndef ELOG_ASYNC_LINE_OUTPUT
+#ifndef ELOG_ASYNC_POLL_GET_LOG_BUF_SIZE
+#define ELOG_ASYNC_POLL_GET_LOG_BUF_SIZE         (ELOG_ASYNC_OUTPUT_BUF_SIZE - 4)
+#endif
+#else
 #ifndef ELOG_ASYNC_POLL_GET_LOG_BUF_SIZE
 #define ELOG_ASYNC_POLL_GET_LOG_BUF_SIZE         (ELOG_LINE_BUF_SIZE - 4)
+#endif
 #endif
 #endif /* ELOG_ASYNC_OUTPUT_USING_PTHREAD */
 
@@ -56,7 +62,7 @@
 static sem_t output_notice;
 /* asynchronous output pthread thread */
 static pthread_t async_output_thread;
-#endif /* ELOG_ASYNC_OUTPUT_USING_PTHREAD */
+#endif /* ELOG_ASYNC_OUTPUT_ENABLE */
 
 /* the highest output level for async mode, other level will sync output */
 #ifdef ELOG_ASYNC_OUTPUT_LVL


### PR DESCRIPTION
1、修改异步输出中每次取数据的大小，未定义ELOG_ASYNC_LINE_OUTPUT时一次取完log_buf，异步数据保存率显著提高
2、修改拼写错误：ELOG_FILE_FLUSH_CAHCE_ENABLE -> ELOG_FILE_FLUSH_CACHE_ENABLE
3、增加ELOG_TERMINAL_ENABLE宏控制日志是否输出到终端，默认开启

测试环境：
1、关闭终端printf，只写文件
2、调整ELOG_FILE_MAX_SIZE  (50 * 1024 * 1024)，避免回滚到其他文件
3、所有日志全异步输出 ELOG_ASYNC_OUTPUT_LVL = ELOG_LVL_ASSERT
4、关闭ELOG_COLOR_ENABLE

修改前，ELOG_ASYNC_OUTPUT_BUF_SIZE = (ELOG_LINE_BUF_SIZE * 100)。
修改后，调整ELOG_ASYNC_OUTPUT_BUF_SIZE成之前一半(ELOG_LINE_BUF_SIZE * 50)，ELOG_ASYNC_POLL_GET_LOG_BUF_SIZE = (ELOG_ASYNC_OUTPUT_BUF_SIZE - 4)
此时占用总内存理论比修改前小一个ELOG_LINE_BUF_SIZE。


测试一：10w日志，测试10次（当然私下测试肯定不止10次了，大体情况如此）
修改前：
记录到文件42.36w条日志，丢失57.64w条，平均耗时95700us：
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo
spend_time:88849us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo
spend_time:86611us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo
spend_time:88133us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo
spend_time:91305us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo
spend_time:91984us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo
spend_time:95073us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo
spend_time:99398us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo
spend_time:105067us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo
spend_time:98810us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo
spend_time:112186us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# wc -l elog_file.log 
423610 elog_file.log

修改后：
记录到文件94.02w条日志，丢失5.98w条，平均耗时99870us：
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo 
spend_time:91511us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo 
spend_time:96746us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo 
spend_time:93980us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo 
spend_time:103324us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo 
spend_time:101263us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo 
spend_time:98919us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo 
spend_time:107741us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo 
spend_time:92426us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo 
spend_time:114078us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo 
spend_time:98718us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# wc -l elog_file.log 
940161 elog_file.log


测试二：1w日志，测试10次（当然私下测试肯定不止10次了，大体情况如此）
修改前：
记录到文件5.74w条日志，丢失4.26w条，平均耗时11400us：
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo
spend_time:11623us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo
spend_time:11188us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo
spend_time:8838us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo
spend_time:9854us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo
spend_time:10680us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo
spend_time:14782us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo
spend_time:8660us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo
spend_time:14345us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo
spend_time:10619us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo
spend_time:13470us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# wc -l elog_file.log 
57364 elog_file.log

修改后：
记录到文件9.79w条日志，丢失0.21w条，平均耗时13500us：
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo
spend_time:16989us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo
spend_time:13363us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo
spend_time:13432us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo
spend_time:11822us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo
spend_time:16490us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo
spend_time:15068us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo
spend_time:10814us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo
spend_time:14494us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo
spend_time:10703us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# ./out/EasyLoggerLinuxDemo
spend_time:12574us
root@5ooo:/home/coder/EasyLogger/demo/os/linux/test# wc -l elog_file.log 
97933 elog_file.log