### PR TITLE
更改函数名称及行号得打印顺序（便于vscode直接跳转）

### DIFF
--- a/easylogger/src/elog.c
+++ b/easylogger/src/elog.c
@@ -632,26 +632,27 @@ void elog_output(uint8_t level, const char *tag, const char *file, const char *f
     /* package file directory and name, function name and line number info */
     if (get_fmt_enabled(level, ELOG_FMT_DIR | ELOG_FMT_FUNC | ELOG_FMT_LINE)) {
         log_len += elog_strcpy(log_len, log_buf + log_len, "(");
-        /* package time info */
+        /* package file info */
         if (get_fmt_enabled(level, ELOG_FMT_DIR)) {
             log_len += elog_strcpy(log_len, log_buf + log_len, file);
             if (get_fmt_enabled(level, ELOG_FMT_FUNC)) {
-                log_len += elog_strcpy(log_len, log_buf + log_len, " ");
+                log_len += elog_strcpy(log_len, log_buf + log_len, ":");
             } else if (get_fmt_enabled(level, ELOG_FMT_LINE)) {
-                log_len += elog_strcpy(log_len, log_buf + log_len, ":");
+                log_len += elog_strcpy(log_len, log_buf + log_len, " ");
             }
         }
-        /* package process info */
-        if (get_fmt_enabled(level, ELOG_FMT_FUNC)) {
-            log_len += elog_strcpy(log_len, log_buf + log_len, func);
-            if (get_fmt_enabled(level, ELOG_FMT_LINE)) {
-                log_len += elog_strcpy(log_len, log_buf + log_len, ":");
-            }
-        }
-        /* package thread info */
+        /* package line info */
         if (get_fmt_enabled(level, ELOG_FMT_LINE)) {
             snprintf(line_num, ELOG_LINE_NUM_MAX_LEN, "%ld", line);
             log_len += elog_strcpy(log_len, log_buf + log_len, line_num);
+            if (get_fmt_enabled(level, ELOG_FMT_FUNC)) {
+                log_len += elog_strcpy(log_len, log_buf + log_len, " ");
+            }
+        }
+        /* package func info */
+        if (get_fmt_enabled(level, ELOG_FMT_FUNC)) {
+            log_len += elog_strcpy(log_len, log_buf + log_len, func);
+            
         }
         log_len += elog_strcpy(log_len, log_buf + log_len, ")");
     }


### PR DESCRIPTION
将打印信息由
`D/main     [2021-07-28 17:07:02] (demo/main.c test_elog:74)Hello EasyLogger!`
更改为
`D/main     [2021-07-28 17:08:30] (demo/main.c:74 test_elog)Hello EasyLogger!`
这样在vscode中可以将鼠标移动至demo/main.c:74处，点击ctrl+单击，即可直接跳转到打印该信息代码所在的行