### PR TITLE
[demo][linux] fix compile warning about old-style-declaration

### DIFF
--- a/demo/os/linux/easylogger/port/elog_file_port.c
+++ b/demo/os/linux/easylogger/port/elog_file_port.c
@@ -73,7 +73,7 @@ ElogErrCode elog_file_port_init(void) {
 /**
  * file log lock
  */
-void inline elog_file_port_lock(void)
+inline void elog_file_port_lock(void)
 {
     semid == -1 ? -1 : semop(semid, (struct sembuf *)&down, 1);
 }
@@ -81,7 +81,7 @@ void inline elog_file_port_lock(void)
 /**
  * file log unlock
  */
-void inline elog_file_port_unlock(void)
+inline void elog_file_port_unlock(void)
 {
     semid == -1 ? -1 : semop(semid, (struct sembuf *)&up, 1);
 }


### PR DESCRIPTION
In gcc 7.3.0, we encountered a warning error when compiling

	elog_file_port.c:76:1: warning: ‘inline’ is not at beginning of declaration [-Wold-style-declaration]

Put 'inline' in front of 'void' can fix it

Signed-off-by: dubaowei <dubaowei@cetc.com>