### PR TITLE
Change the buf parameter type of elog_hexdump

### DIFF
--- a/easylogger/inc/elog.h
+++ b/easylogger/inc/elog.h
@@ -199,7 +199,7 @@ extern void (*elog_assert_hook)(const char* expr, const char* func, size_t line)
 void elog_assert_set_hook(void (*hook)(const char* expr, const char* func, size_t line));
 int8_t elog_find_lvl(const char *log);
 const char *elog_find_tag(const char *log, uint8_t lvl, size_t *tag_len);
-void elog_hexdump(const char *name, uint8_t width, uint8_t *buf, uint16_t size);
+void elog_hexdump(const char *name, uint8_t width, const void *buf, uint16_t size);
 
 #define elog_a(tag, ...)     elog_assert(tag, __VA_ARGS__)
 #define elog_e(tag, ...)     elog_error(tag, __VA_ARGS__)

--- a/easylogger/src/elog.c
+++ b/easylogger/src/elog.c
@@ -848,12 +848,13 @@ const char *elog_find_tag(const char *log, uint8_t lvl, size_t *tag_len) {
  * @param buf hex buffer
  * @param size buffer size
  */
-void elog_hexdump(const char *name, uint8_t width, uint8_t *buf, uint16_t size)
+void elog_hexdump(const char *name, uint8_t width, const void *buf, uint16_t size)
 {
 #define __is_print(ch)       ((unsigned int)((ch) - ' ') < 127u - ' ')
 
     uint16_t i, j;
     uint16_t log_len = 0;
+    const uint8_t *buf_p = buf;
     char dump_string[8] = {0};
     int fmt_result;
 
@@ -883,7 +884,7 @@ void elog_hexdump(const char *name, uint8_t width, uint8_t *buf, uint16_t size)
         /* dump hex */
         for (j = 0; j < width; j++) {
             if (i + j < size) {
-                snprintf(dump_string, sizeof(dump_string), "%02X ", buf[i + j]);
+                snprintf(dump_string, sizeof(dump_string), "%02X ", buf_p[i + j]);
             } else {
                 strncpy(dump_string, "   ", sizeof(dump_string));
             }
@@ -896,7 +897,7 @@ void elog_hexdump(const char *name, uint8_t width, uint8_t *buf, uint16_t size)
         /* dump char for hex */
         for (j = 0; j < width; j++) {
             if (i + j < size) {
-                snprintf(dump_string, sizeof(dump_string), "%c", __is_print(buf[i + j]) ? buf[i + j] : '.');
+                snprintf(dump_string, sizeof(dump_string), "%c", __is_print(buf_p[i + j]) ? buf_p[i + j] : '.');
                 log_len += elog_strcpy(log_len, log_buf + log_len, dump_string);
             }
         }


### PR DESCRIPTION
Change the 'buf' parameter type from uint8_t* to const void*.

Signed-off-by: FragrantRye <903465575@qq.com>