### PR TITLE
fix: 修复在关闭OUTPUT_LOCK的情况下依然会调用elog_port_output_lock函数的bug [issue 122]

### DIFF
--- a/easylogger/src/elog.c
+++ b/easylogger/src/elog.c
@@ -428,7 +428,7 @@ void elog_set_filter_tag_lvl(const char *tag, uint8_t level)
         return;
     }
 
-    elog_port_output_lock();
+    elog_output_lock();
     /* find the tag in arr */
     for (i =0; i< ELOG_FILTER_TAG_LVL_MAX_NUM; i++){
         if (elog.filter.tag_lvl[i].tag_use_flag == true &&
@@ -481,7 +481,7 @@ uint8_t elog_get_filter_tag_lvl(const char *tag)
         return level;
     }
 
-    elog_port_output_lock();
+    elog_output_lock();
     /* find the tag in arr */
     for (i =0; i< ELOG_FILTER_TAG_LVL_MAX_NUM; i++){
         if (elog.filter.tag_lvl[i].tag_use_flag == true &&


### PR DESCRIPTION
在elog.c中的elog_get_filter_tag_lvl函数以及elog_set_filter_tag_lvl函数中错误地使用了elog_port_output_lock函数导致在关闭output lock的情况下仍然会锁定输出却无法解锁

解决:将elog_get_filter_tag_lvl和elog_set_filter_tag_lvl函数中的elog_port_output_lock函数改为elog_output_lock函数

issue #122
close #122