### PR TITLE
增加对文件空指针的判断

### DIFF
--- a/easylogger/plugins/file/elog_file.c
+++ b/easylogger/plugins/file/elog_file.c
@@ -69,7 +69,7 @@ static bool elog_file_rotate(void)
 #define SUFFIX_LEN                     10
     /* mv xxx.log.n-1 => xxx.log.n, and xxx.log => xxx.log.0 */
     int n, err = 0;
-    char oldpath[256], newpath[256];
+    char oldpath[256]= {0}, newpath[256] = {0};
     size_t base = strlen(local_cfg.name);
     bool result = true;
     FILE *tmp_fp;

--- a/easylogger/plugins/file/elog_file.c
+++ b/easylogger/plugins/file/elog_file.c
@@ -113,6 +113,9 @@ void elog_file_write(const char *log, size_t size)
 
     ELOG_ASSERT(init_ok);
     ELOG_ASSERT(log);
+    if(fp == NULL) {
+    	return;
+    }
 
     elog_file_port_lock();
 


### PR DESCRIPTION
elog_file_write函数未对空指针进行判断而直接使用
void elog_file_write(const char *log, size_t size)
{
    size_t file_size = 0;

    ELOG_ASSERT(init_ok);
    ELOG_ASSERT(log);
    if(fp == NULL) {
    	return;
    }

    elog_file_port_lock();

    fseek(fp, 0L, SEEK_END);
    file_size = ftell(fp);

-----