### PR TITLE
[features]: 实现中断上下文打印输出特性支持

### DIFF
--- a/easylogger/inc/elog_cfg.h
+++ b/easylogger/inc/elog_cfg.h
@@ -73,5 +73,8 @@
 #define ELOG_BUF_OUTPUT_ENABLE
 /* buffer size for buffered output mode */
 #define ELOG_BUF_OUTPUT_BUF_SIZE                 (ELOG_LINE_BUF_SIZE * 10)
+/*---------------------------------------------------------------------------*/
+/* enable use elog in isr context */
+// #define ELOG_USING_ISR_LOG
 
 #endif /* _ELOG_CFG_H_ */

--- a/easylogger/port/elog_port.c
+++ b/easylogger/port/elog_port.c
@@ -73,6 +73,24 @@ void elog_port_interrupt_get_nest(void) {
 }
 
 /**
+ * output lock in isr context
+ */
+void elog_port_output_lock_isr(void) {
+
+    /* add your code here */
+
+}
+
+/**
+ * output unlock in isr context
+ */
+void elog_port_output_unlock_isr(void) {
+
+    /* add your code here */
+
+}
+
+/**
  * output lock
  */
 void elog_port_output_lock(void) {

--- a/easylogger/port/elog_port.c
+++ b/easylogger/port/elog_port.c
@@ -72,6 +72,8 @@ void elog_port_interrupt_get_nest(void) {
 
 }
 
+#ifdef ELOG_USING_ISR_LOG
+
 /**
  * output lock in isr context
  */
@@ -89,6 +91,8 @@ void elog_port_output_unlock_isr(void) {
     /* add your code here */
 
 }
+
+#endif
 
 /**
  * output lock

--- a/easylogger/port/elog_port.c
+++ b/easylogger/port/elog_port.c
@@ -25,7 +25,7 @@
  * Function: Portable interface for each platform.
  * Created on: 2015-04-28
  */
- 
+
 #include <elog.h>
 
 /**
@@ -37,7 +37,7 @@ ElogErrCode elog_port_init(void) {
     ElogErrCode result = ELOG_NO_ERR;
 
     /* add your code here */
-    
+
     return result;
 }
 
@@ -58,27 +58,36 @@ void elog_port_deinit(void) {
  * @param size log size
  */
 void elog_port_output(const char *log, size_t size) {
-    
+
     /* add your code here */
-    
+
+}
+
+/**
+ *  interrupt get nest level
+ */
+void elog_port_interrupt_get_nest(void) {
+
+    /* add your code here */
+
 }
 
 /**
  * output lock
  */
 void elog_port_output_lock(void) {
-    
+
     /* add your code here */
-    
+
 }
 
 /**
  * output unlock
  */
 void elog_port_output_unlock(void) {
-    
+
     /* add your code here */
-    
+
 }
 
 /**
@@ -87,9 +96,9 @@ void elog_port_output_unlock(void) {
  * @return current time
  */
 const char *elog_port_get_time(void) {
-    
+
     /* add your code here */
-    
+
 }
 
 /**
@@ -98,9 +107,9 @@ const char *elog_port_get_time(void) {
  * @return current process name
  */
 const char *elog_port_get_p_info(void) {
-    
+
     /* add your code here */
-    
+
 }
 
 /**
@@ -109,7 +118,7 @@ const char *elog_port_get_p_info(void) {
  * @return current thread name
  */
 const char *elog_port_get_t_info(void) {
-    
+
     /* add your code here */
-    
+
 }

--- a/easylogger/src/elog.c
+++ b/easylogger/src/elog.c
@@ -149,6 +149,8 @@ void (*elog_assert_hook)(const char* expr, const char* func, size_t line);
 
 extern void elog_port_output(const char *log, size_t size);
 extern int elog_port_interrupt_get_nest(void);
+extern void elog_port_output_lock_isr(void);
+extern void elog_port_output_unlock_isr(void);
 extern void elog_port_output_lock(void);
 extern void elog_port_output_unlock(void);
 
@@ -385,6 +387,9 @@ void elog_output_lock(void) {
         } else {
             elog.output_is_locked_before_enable = true;
         }
+    } else {
+        if (elog.output_lock_enabled)
+            elog_port_output_lock_isr();
     }
 }
 
@@ -399,6 +404,9 @@ void elog_output_unlock(void) {
         } else {
             elog.output_is_locked_before_enable = false;
         }
+    } else {
+        if (elog.output_lock_enabled)
+            elog_port_output_unlock_isr();
     }
 }
 


### PR DESCRIPTION
  1. 判断当前log输出上下文
  2. 中断上下文与任务上下文使用单独输出buffer
  3. 不支持中断嵌套模式下中断输出调用
  4. 添加接口判断是否处于中断上下文

hi 你好：
    我希望实现该log日志输出支持在中断上下文进行，相关代码修改请问是否合适